### PR TITLE
Window tweaks

### DIFF
--- a/velour.go
+++ b/velour.go
@@ -95,7 +95,12 @@ func main() {
 
 	serverWin = newWin("")
 	if !*debug {
-		defer serverWin.del()
+		defer func(){
+			serverWin.del()
+			for _, win := range wins {
+				win.del()
+			}
+		}()
 	}
 	serverWin.Fprintf("tag", "Chat ")
 	// Set Dump handling for the server window.


### PR DESCRIPTION
Fixes #1, if indirectly. Now closing the server window closes all chat windows, unless velour was started with `-d`.
