### PR TITLE
Reply with a PONG if PINGed during nick registration.

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -97,6 +97,16 @@ func (c *Client) register(nick, fullname, pass string) error {
 			c.Server = msg.Origin
 			return nil
 
+		case PING:
+			// Some IRC servers (UnrealIRCd) use PING-based IP
+			// spoofin prevention: they send a PING with some
+			// junk and  require the client to reply with a PONG
+			// that include the same junk. If the client is an IP
+			// spoofer, they cannot see the PING, and thus cannot
+			// reply with the same junk. We aren't spoofing, so
+			// lets give them the junk that they want.
+			c.Out <- Msg{Cmd: PONG, Args: msg.Args}
+
 		default:
 			/* ignore */
 		}


### PR DESCRIPTION
The PONG includes the same arguments as the reveived PING. This is an
IP spoofing prevention technique used by some servers.
