### PR TITLE
Set connection deadlines

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"time"
 )
 
 // A Client is a client's connection to an IRC server.
@@ -114,6 +115,8 @@ func (c *Client) register(nick, fullname, pass string) error {
 	return errors.New("unexpected end of file")
 }
 
+const deadline = 1 * time.Minute
+
 // readMsgs reads messages from the client and
 // sends them on the message channel.  If an
 // error occurs then it is sent on the errs channel,
@@ -122,6 +125,7 @@ func (c *Client) register(nick, fullname, pass string) error {
 func (c *Client) readMsgs(errs chan<- error, ms chan<- Msg) {
 	in := bufio.NewReader(c.conn)
 	for {
+		c.conn.SetReadDeadline(time.Now().Add(deadline))
 		m, err := readMsg(in)
 		if err != nil {
 			errs <- err
@@ -154,6 +158,7 @@ func (c *Client) writeMsgs(errs chan<- error, ms <-chan Msg) {
 			errs <- err
 			break
 		}
+		c.conn.SetWriteDeadline(time.Now().Add(deadline))
 		if err = out.Flush(); err != nil {
 			errs <- err
 			break


### PR DESCRIPTION
An attempt to catch network disconnects sooner. I don’t think this will work as-is (at least the read one), but I figured I’d put it into a PR for chewing on.
