### PR TITLE
On receiving ERR_NOTONCHANNEL, close the channel window.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: go
 script: "./gok.sh"
 install:
     - export PATH="$HOME/gopath/bin:$PATH"
-    - go get code.google.com/p/go.tools/cmd/vet
+    - go get golang.org/x/tools/cmd/vet
     - go get github.com/golang/lint/golint
     - go get -d -v ./... && go build -v ./...


### PR DESCRIPTION
It's possible to open a window for a channel that is not JOINed.
One way is to do TOPIC <channel> for a non-JOINed channel.
Before this change, it was not possible to close such a window,
because instead of getting a PART reply, the server sends an ERR_NOTONCHANNEL.
This CL closes the channel window when it gets an ERR_NOTONCHANNEL.

Fixes #29.